### PR TITLE
fix module 'keras.backend' has no attribute 'control_flow_ops' #48

### DIFF
--- a/2_Training/src/keras_yolo3/yolo3/model.py
+++ b/2_Training/src/keras_yolo3/yolo3/model.py
@@ -13,6 +13,9 @@ from keras.regularizers import l2
 
 from ..yolo3.utils import compose
 
+# fixed module 'keras.backend' has no attribute 'control_flow_ops'
+# https://github.com/AntonMu/TrainYourOwnYOLO/issues/48
+K.control_flow_ops = tf
 
 @wraps(Conv2D)
 def DarknetConv2D(*args, **kwargs):


### PR DESCRIPTION
I've encountered the same error for tensorflow 1.15.0.
As this issue: https://github.com/tensorflow/tensorflow/issues/7020:  `control_flow_ops` is not public API now.
