### PR TITLE
Set to closest available version of opencv-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ nbconvert==5.5.0
 nbformat==4.4.0
 notebook==5.7.8
 numpy==1.16.4
-opencv-python==4.1.0.25
+opencv-python==4.1.2.30
 pandas==0.24.2
 pandocfilters==1.4.2
 parso==0.5.0


### PR DESCRIPTION
Fixes `pip install -r requirements` error:

```shell
ERROR: Could not find a version that satisfies the requirement opencv-python==4.1.0.25 (from -r requirements.txt (line 45)) (from versions: 3.4.8.29, 3.4.9.31, 4.1.2.30, 4.2.0.32)
ERROR: No matching distribution found for opencv-python==4.1.0.25 (from -r requirements.txt (line 45))
```