### PR TITLE
Minor fix for detector, default [ ] for file_types flag was empty.

### DIFF
--- a/3_Inference/Detector.py
+++ b/3_Inference/Detector.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
         "--file_types",
         "--names-list",
         nargs="*",
-        default=[],
+        default=[".jpg, .jpeg, .png, .mp4, .JPG"],
         help="Specify list of file types to include. Default is --file_types .jpg .jpeg .png .mp4",
     )
 


### PR DESCRIPTION
 Fixed the default list for file_types flag; it was empty. Added .JPG to the list, some cameras saves images as .JPG instead of .jpg